### PR TITLE
run nginx in foreground

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ VOLUME ["/var/log/nginx"]
 EXPOSE 80
 EXPOSE 443
 
-CMD ["/usr/sbin/nginx"]
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,7 @@ events {
 }
 
 http {
+    types_hash_max_size 2048;
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
run nginx in foreground an fix 

nginx: [warn] could not build optimal types_hash, you should increase either types_hash_max_size: 1024 or types_hash_bucket_size: 64; ignoring types_hash_bucket_size